### PR TITLE
Fix refs without items

### DIFF
--- a/src/Store.ts
+++ b/src/Store.ts
@@ -230,6 +230,10 @@ export class Store extends NetworkStore {
     const refs: Array<string> = obj.relationships ? Object.keys(obj.relationships) : [];
     refs.forEach((ref: string) => {
       const items = obj.relationships[ref].data;
+      if (items instanceof Array && items.length < 1) {
+        // it's only possible to update items with one ore more refs. Early exit
+        return;
+      }
       if (items) {
         const models: IModel|Array<IModel> = mapItems<IModel>(items, ({id, type}) => this.find(type, id) || id);
         const type: string = items instanceof Array ? items[0].type : items.type;


### PR DESCRIPTION
This will fix an `Uncaught (in promise) TypeError: Cannot read property
'type' of undefined` error when an item has no data in references.

(It was not possible for me to let the rests run on my windows machine, one show stopper was `NODE_ENV=test` in `scripts.test` in `package.json`, the other was somewhere in husky, i think somewhere in tsc. Anyway, here the barebone code)