### PR TITLE
Fix implicit any in handleResponse return type

### DIFF
--- a/dist/NetworkUtils.d.ts
+++ b/dist/NetworkUtils.d.ts
@@ -86,4 +86,4 @@ export declare function remove(store: Store, url: string, headers?: IHeaders, op
  * @returns {Promise<LibResponse>} Response promise
  */
 export declare function fetchLink(link: JsonApi.ILink, store: Store, requestHeaders?: IDictionary<string>, options?: IRequestOptions): Promise<LibResponse>;
-export declare function handleResponse(record: Record, prop?: string): (LibResponse) => Record;
+export declare function handleResponse(record: Record, prop?: string): (response: LibResponse) => Record;

--- a/src/NetworkUtils.ts
+++ b/src/NetworkUtils.ts
@@ -286,7 +286,7 @@ export function fetchLink(
   return Promise.resolve(new LibResponse({data: null}, store));
 }
 
-export function handleResponse(record: Record, prop?: string): (LibResponse) => Record {
+export function handleResponse(record: Record, prop?: string): (response: LibResponse) => Record {
   return (response: LibResponse): Record => {
 
     /* istanbul ignore if */


### PR DESCRIPTION
Hey there, thanks for the great library!

This fixes a minor typing issue when using `noImplicitAny: true` in consuming libraries.

```
(89,73): error TS7006: Parameter 'LibResponse' implicitly has an 'any' type.
```